### PR TITLE
fix: injection of multiple services

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export default function({ types: t }) {
           } else {
             fCmd = ctor.body.body;
           }
-          if(fCmd && fCmd.expression.callee.type === 'Super') {
+          if(fCmd && fCmd.expression.callee && fCmd.expression.callee.type === 'Super') {
             sup = ctor.body.body.shift();
           }
 


### PR DESCRIPTION
When using the format:

``` lang:javascript
@Inject('$scope', '$http')
```

the plugin fails with an error `Cannot read property 'type' of undefined`.

This commit fixes this issue.
