### PR TITLE
Update README to explicitly specify dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 $ npm install --save-dev babel-plugin-ng-annotate
 ```
 
+Note: this library depends on the [syntax decorators](https://www.npmjs.com/package/babel-plugin-syntax-decorators) plugin for parsing. Simply `$ npm install --save-dev babel-plugin-syntax-decorators` and follow the setup instructions below.
+
 ## How to setup
 
 #### .babelrc


### PR DESCRIPTION
Removes a possible point of confusion with usage; personally, it took me a couple minutes to grok that syntax decorators was a hard dependency.
