### PR TITLE
Fixes #5 and handles an inheritance issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
     "angular",
     "annotate"
   ],
-  "devDependencies": {}
+  "devDependencies": {
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.7.2",
+    "babel-preset-es2015": "^6.6.0"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,11 @@ export default function({ types: t }) {
             [],
             t.blockStatement([])
           );
+          if (path.node.superClass) {
+            ctor.body.body.unshift(
+              t.expressionStatement(t.callExpression(t.super(), []))
+            );
+          }
           path.node.body.body.unshift(ctor);
           toParam = toInject;
         } else {
@@ -37,7 +42,7 @@ export default function({ types: t }) {
           } else {
             fCmd = ctor.body.body;
           }
-          if(fCmd && fCmd.expression.callee && fCmd.expression.callee.type === 'Super') {
+          if(fCmd && fCmd.expression && fCmd.expression.callee && fCmd.expression.callee.type === 'Super') {
             sup = ctor.body.body.shift();
           }
 


### PR DESCRIPTION
The issue @LostCrew and @joliveros are having is that the first statement in the constructor is not an expression node. Instead they have a variable declaration. Line 45 fixes the `Cannot read property 'callee' of undefined` issue.

The other part of this PR deals with cases like this:

``` javascript
@Inject('$scope', '$element', '$attrs')
class B extends A {

  sayHi() {
    console.log('hi');
  }

}
```

Without this change we will encounter the `'this' is not allowed before super()` error. Once the fix is applied we obtain the desired result:

``` javascript
var B = function (_A) {
  (0, _inherits3.default)(B, _A);

  function B($scope, $element, $attrs) {
    (0, _classCallCheck3.default)(this, B);

    var _this = (0, _possibleConstructorReturn3.default)(this, (0, _getPrototypeOf2.default)(B).call(this));

    _this.$attrs = $attrs;
    _this.$element = $element;
    _this.$scope = $scope;
    return _this;
  }

  (0, _createClass3.default)(B, [{
    key: 'sayHi',
    value: function sayHi() {
      console.log('hi');
    }
  }]);
  return B;
}(A);

B.$inject = ['$scope', '$element', '$attrs'];

```
