### PR TITLE
Rename 'Inject' into 'inject'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Note: this library depends on the [syntax decorators](https://www.npmjs.com/pack
 ## How to use
 
 ```js
-@Inject('service1', 'service2', 'service3')
+@inject('service1', 'service2', 'service3')
 class MyController {
 
     constructor() {

--- a/example/src/ExampleController.js
+++ b/example/src/ExampleController.js
@@ -1,5 +1,5 @@
 
-@Inject('$exService')
+@inject('$exService')
 export class ExampleController {
 
   constructor() {

--- a/example/src/ExampleService.js
+++ b/example/src/ExampleService.js
@@ -1,4 +1,4 @@
-@Inject('$http')
+@inject('$http')
 class ExampleService {
 
   getData() {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export default function ({ types: t }) {
         if (!path.node.decorators) {
           return;
         }
-        const inject = path.node.decorators.find(decorator => decorator.expression.callee.name === 'Inject');
+        const inject = path.node.decorators.find(decorator => decorator.expression.callee.name === 'inject');
 
         if (!inject) {
           return;


### PR DESCRIPTION
Decorators are functions, not contructors. As such, they must be declared in lowercase, not PascalCase. In fact, ESLint [complains](http://eslint.org/docs/rules/new-cap) about it and it's a pain to suppress it inline all the times you need `@Inject`.
This PR solves that. Thanks in advance for accepting it.
